### PR TITLE
Remove LTO For Release Builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,9 +58,6 @@ rand = "0.8.3"
 opt-level = 1
 debug = 0
 
-[profile.release]
-lto = true
-
 # Add some examples explicitly so we can say they requires the extra `ldtk`
 # or `epaint` features.
 [[example]]


### PR DESCRIPTION
The amount of time it took to do a release buid was detrimental for a
new user ( #50 ) and we don't really need it for this repository because
no real games are built from this repo.